### PR TITLE
[improvement] Option for library to not wait on empty promise nodejs queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "event-wait",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "simple zero dependency library that implements one of the simplest mechanisms for communication between event loop execution contexts (with signals and no polling)",
     "main": "built/index.js",
     "types": "built/index.d.ts",

--- a/readme.MD
+++ b/readme.MD
@@ -30,6 +30,17 @@ There is no polling implemented for promises that wait for the set signal. The c
 Documentation by example:
 
 ```javascript
+// if users doesn't have anything in event loop, this library keeps the process running and waiting for events.
+// otherwise it could unexpectedly close down node process for user. (because our promise resolves on event and is not in event loop)
+// https://github.com/nodejs/node/issues/22088
+
+// if you don't want that behaviour call this function before using library objects and program will exit when there are no more promises in nodejs queue.
+const { ignorePromiseResolutionHaltExit  } = require('event-wait')
+ignorePromiseResolutionHaltExit();
+```
+
+
+```javascript
 async function wait_event_example1() {
     // Straight-forward example.
     const log = (txt) => console.log(txt, new Date().toISOString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { createConsumerProducerEventObject } from "./consumer-producer-event";
-import { createWaitEventObject } from "./wait-event";
+import { createWaitEventObject, ignorePromiseResolutionHaltExit } from "./wait-event";
 
 export {
     createWaitEventObject,
-    createConsumerProducerEventObject
+    createConsumerProducerEventObject,  
+    ignorePromiseResolutionHaltExit
 };


### PR DESCRIPTION
added an option by calling a function for the library to ignore keep alive of the program if promise queue is empty